### PR TITLE
Fix profile image url for selecting service image in edit profile

### DIFF
--- a/app/lib/CreateUser.js
+++ b/app/lib/CreateUser.js
@@ -4,7 +4,7 @@ Accounts.onCreateUser(function (options, user) {
      options.profile.avatar = user.services.twitter.profile_image_url;
      user.profile = options.profile;
      user.profile.images = user.profile.images || [];
-     user.profile.images.push([options.profile.avatar])
+     user.profile.images.push(options.profile.avatar)
    }
  }
 
@@ -13,7 +13,7 @@ if(user.services.facebook) {
    options.profile.avatar = "http://graph.facebook.com/" + user.services.facebook.id + "/picture/?width=50&height=50";
    user.profile = options.profile;
    user.profile.images = user.profile.images || [];
-   user.profile.images.push([options.profile.avatar])
+   user.profile.images.push(options.profile.avatar)
   }
   if (user.services.facebook.email) {
     user.emails = user.emails || [];
@@ -26,7 +26,7 @@ if(user.services.facebook) {
      options.profile.avatar = user.services.google.picture;
      user.profile = options.profile;
      user.profile.images = user.profile.images || [];
-     user.profile.images.push([options.profile.avatar])
+     user.profile.images.push(options.profile.avatar)
    }
    if (user.services.google.email) {
      user.emails = user.emails || [];


### PR DESCRIPTION
When you edit a profile, you can upload a new image and choose it. However, if you created an account with a service (google/facebook,twitter) it will have added the image as an array to user.profile.images. 
Schema method User.setProfileImage expects string via check.

Simply removed the brackets from options.profile.avatar in lib -> CreateUser.js.